### PR TITLE
Add more stats to the timely computation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 #![allow(deprecated)] // arg_enum! uses deprecated stuff
 
 use crate::intern;
-use crate::output::Output;
+use crate::output::{Output, OutputStatsLevel};
 use crate::tab_delim;
 use failure::Error;
 use std::path::Path;
@@ -46,9 +46,19 @@ pub fn main(opt: Opt) -> Result<(), Error> {
 
             let result: Result<(Duration, Output), Error> = do catch {
                 let verbose = opt.verbose | opt.stats;
+                let stats_level = if opt.stats {
+                    let stats_level = if opt.verbose {
+                        OutputStatsLevel::Precise
+                    } else {
+                        OutputStatsLevel::Summary
+                    };
+                    Some(stats_level)
+                } else {
+                    None
+                };
                 let algorithm = opt.algorithm;
                 let all_facts = tab_delim::load_tab_delimited_facts(tables, &Path::new(&facts_dir))?;
-                timed(|| Output::compute(&all_facts, algorithm, verbose))
+                timed(|| Output::compute(&all_facts, algorithm, verbose, stats_level))
             };
 
             match result {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -36,11 +36,21 @@ crate struct Output {
     crate region_degrees: tracking::RegionDegrees,
 }
 
+crate enum OutputStatsLevel {
+    Summary,
+    Precise,
+}
+
 impl Output {
-    crate fn compute(all_facts: &AllFacts, algorithm: Algorithm, dump_enabled: bool) -> Self {
+    crate fn compute(
+        all_facts: &AllFacts,
+        algorithm: Algorithm,
+        dump_enabled: bool,
+        stats_level: Option<OutputStatsLevel>,
+    ) -> Self {
         match algorithm {
             Algorithm::Naive => naive::compute(dump_enabled, all_facts.clone()),
-            Algorithm::TimelyOpt => timely_opt::compute(dump_enabled, all_facts.clone()),
+            Algorithm::TimelyOpt => timely_opt::compute(dump_enabled, stats_level, all_facts.clone()),
         }
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -17,8 +17,8 @@ fn test_fn(dir_name: &str, fn_name: &str) -> Result<(), Error> {
         println!("facts_dir = {:?}", facts_dir);
         let tables = &mut intern::InternerTables::new();
         let all_facts = tab_delim::load_tab_delimited_facts(tables, &facts_dir)?;
-        let naive = Output::compute(&all_facts, Algorithm::Naive, false);
-        let timely_opt = Output::compute(&all_facts, Algorithm::TimelyOpt, false);
+        let naive = Output::compute(&all_facts, Algorithm::Naive, false, None);
+        let timely_opt = Output::compute(&all_facts, Algorithm::TimelyOpt, false, None);
         assert_eq!(naive.borrow_live_at, timely_opt.borrow_live_at);
         // FIXME: check `_result` somehow
     }


### PR DESCRIPTION
This updates `--stats` to add counts about the input relations, output relation, and the other 2 that were dumped in verbose mode.

This also adds timely tracing about a lot of the computation subparts, displayed in "verbose stats" mode: when both `--stats` and `-v` are used.

<details>
<summary>Example `--stats` output, on the clap dataset</summary>

```
--------------------------------------------------
Input relations stats:
Point count: 49002
Region count (incl. universal regions): 1892

'cfg_edge' tuple count: 51896
'killed' tuple count: 980
'outlives' tuple count: 534327
'region_live_at' tuple count: 1076158
'universal_region' tuple count: 6
--------------------------------------------------
Main relations stats:
'subset' final tuple count: 2714121
'requires' final tuple count: 858674
--------------------------------------------------
Output stats:
'borrow_live_at' final tuple count: 832392
--------------------------------------------------
Directory: inputs/clap-rs/app-parser-{{impl}}-add_defaults/
Time: 32.280s
In-degree stats
# Number of samples = 1005243
# Min = 1
# Max = 16
#
# Mean = 2.699965083069363
# Standard deviation = 1.7976645408699201
# Variance = 3.231597801501061
#
# Each ∎ is a count of 11368
#
 1 ..  3 [ 568412 ]: ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
 3 ..  5 [ 282166 ]: ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
 5 ..  7 [ 117833 ]: ∎∎∎∎∎∎∎∎∎∎
 7 ..  9 [  32292 ]: ∎∎
 9 .. 11 [   2092 ]: 
11 .. 13 [    396 ]: 
13 .. 15 [     36 ]: 
15 .. 17 [   2016 ]: 
17 .. 19 [      0 ]: 
19 .. 21 [      0 ]: 

Out-degree stats
# Number of samples = 1005243
# Min = 1
# Max = 16
#
# Mean = 2.699965083069363
# Standard deviation = 1.7976645408699201
# Variance = 3.231597801501061
#
# Each ∎ is a count of 11368
#
 1 ..  3 [ 568412 ]: ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
 3 ..  5 [ 282166 ]: ∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
 5 ..  7 [ 117833 ]: ∎∎∎∎∎∎∎∎∎∎
 7 ..  9 [  32292 ]: ∎∎
 9 .. 11 [   2092 ]: 
11 .. 13 [    396 ]: 
13 .. 15 [     36 ]: 
15 .. 17 [   2016 ]: 
17 .. 19 [      0 ]: 
19 .. 21 [      0 ]: 
```

</details>


<details>
<summary>Snippet of `-v --stats`, on the clap dataset</summary>

```
--------------------------------------------------
Input relations stats:
Point count: 49002
Region count (incl. universal regions): 1892

'cfg_edge' tuple count: 51896
'killed' tuple count: 980
'outlives' tuple count: 534327
'region_live_at' tuple count: 1076158
'universal_region' tuple count: 6
--------------------------------------------------
Timely computation stats:
'subset_before_distinct' - round 0, new facts: 534327
'subset' - round 1, new facts: 534231
'live_to_dead_regions' - round 1, new facts: 25044
'dead_region_requires' - round 1, new facts: 1886
'dead_can_reach_origins' - round 1, new facts: 25966
'subset_before_distinct' - round 1, new facts: 479088
...
'dead_region_requires' - round 1431, new facts: 1
--------------------------------------------------
Main relations stats:
'subset' final tuple count: 2714121
'requires' final tuple count: 858674
...
```

[Complete, very verbose, example output](https://gist.github.com/lqd/cb87af80e7d7f628dee9c8330fc9b6a0)
</details>