### PR TITLE
Make DatafrogOpt produce errors

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -20,7 +20,7 @@ fn test_fn(dir_name: &str, fn_name: &str) -> Result<(), Error> {
         let tables = &mut intern::InternerTables::new();
         let all_facts = tab_delim::load_tab_delimited_facts(tables, &facts_dir)?;
         let naive = Output::compute(&all_facts, Algorithm::Naive, false);
-        let opt = Output::compute(&all_facts, Algorithm::DatafrogOpt, false);
+        let opt = Output::compute(&all_facts, Algorithm::DatafrogOpt, true);
         assert_eq!(naive.borrow_live_at, opt.borrow_live_at);
     }
 }
@@ -58,5 +58,21 @@ fn test_insensitive_potential_error() -> Result<(), Error> {
         expected.insert(Point::from(2), vec![Loan::from(2)]);
 
         assert_eq!(insensitive.potential_errors, expected);
+    }
+}
+
+#[test]
+fn test_sensitive_passes_issue_47680() -> Result<(), Error> {
+    do catch {
+        let facts_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("inputs")
+            .join("issue-47680")
+            .join("nll-facts")
+            .join("main");
+        let tables = &mut intern::InternerTables::new();
+        let all_facts = tab_delim::load_tab_delimited_facts(tables, &facts_dir)?;
+        let sensitive = Output::compute(&all_facts, Algorithm::DatafrogOpt, false);
+
+        assert!(sensitive.potential_errors.is_empty());
     }
 }


### PR DESCRIPTION
- Produce "errors" tuples primarily
- Produce "borrow_live_at" tuples only in verbose mode
- Adds a test to check that issue 47680 does not produce the potential errors produced by the location-insensitive analysis.
- Made the tests run in Verbose mode for the Opt algorithm so that the `borrow_live_at` tuples
are available.

And a couple cleanups:
- Separate static data inputs
- Rename a relation named like an index

As this adds a join with a big relation in the clap benchmark, it is expected to have a slowdown, which we can most likely eliminate when adding leapjoins.

Manually tested that this produces the same `borrow_live_at` and verbose data as before. Unfortunately, there are no inputs that would fail the location-sensitive analysis in the repo such as this [important test case](https://github.com/rust-lang/rust/issues/47680#issuecomment-363144783). (And I don't have the custom rustc adding these `invalidates` tuples)