### PR TITLE
Start implementing the friendly front-end format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 **/*.rs.bk
+/*/Cargo.lock
+/*/target/
+polonius-parser/src/parser.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,30 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ascii-canvas"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -17,6 +38,16 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "skeptic 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -51,6 +82,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +102,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "block-buffer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -115,13 +173,56 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "debug_unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "difference"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "digest"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "docopt"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ena"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -157,6 +258,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +280,14 @@ dependencies = [
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "generic-array"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "glob"
@@ -184,8 +303,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-snap 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lalrpop-snap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -194,14 +381,58 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "memchr"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ordermap"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "petgraph"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "polonius"
@@ -213,6 +444,7 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "histo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "polonius-engine 0.4.0",
+ "polonius-parser 0.1.0",
  "rustc-hash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -224,6 +456,20 @@ dependencies = [
  "datafrog 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "polonius-parser"
+version = "0.1.0"
+dependencies = [
+ "lalrpop 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -294,6 +540,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +650,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "skeptic"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +687,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "string_cache"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache_shared"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -462,6 +805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +832,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ucd-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,8 +866,34 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -510,12 +907,22 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -528,13 +935,21 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
+"checksum ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b385d69402821a1c254533a011a312531cbcc0e3e24f19bbb4747a5a2daf37e2"
 "checksum assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72342c21057a3cb5f7c2d849bf7999a83795434dd36d74fa8c24680581bd1930"
+"checksum atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0fd4c0631f06448cc45a6bbb3b710ebb7ff8ccb96a0800c994afe23a70d5df2"
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
 "checksum backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbdd17cd962b570302f5297aea8648d5923e22e555c2ed2d8b2e34eca646bf6d"
 "checksum backtrace-sys 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3951a5d75651d5817056daf3132ed9cd7918bc7f2afc313b379009e832209a4d"
+"checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
+"checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum bytecount 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "882585cd7ec84e902472df34a5e01891202db3bf62614e1f0afe459c1afcf744"
 "checksum cargo_metadata 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ebd6272a2ca4fd39dbabbd6611eb03df45c2259b3b80b39a9ff8fbdcf42a4b3"
 "checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
@@ -542,20 +957,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
 "checksum colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0aa3473e85a3161b59845d6096b289bb577874cafeaf75ea1b1beaa6572c7fc"
 "checksum datafrog 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "16d724bf4ffe77cdceeecd461009b5f8d9e23c5d645d68bedb4586bf43e7e142"
+"checksum debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
+"checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
+"checksum digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "00a49051fef47a72c9623101b19bd71924a45cca838826caae3eaa4d00772603"
+"checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe5a5078ac8c506d3e4430763b1ba9b609b1286913e7d08e581d1c2de9b7e5"
 "checksum environment 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum histo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a4195184b16b1e8e50353b41f83ad743b80d687b4c41a6f1d0d50231325e258"
+"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lalrpop 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ba451f7bd819b7afc99d4cf4bdcd5a4861e64955ba9680ac70df3a50625ad6cf"
+"checksum lalrpop-snap 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "60013fd6be14317d43f47658b1440956a9ca48a9ed0257e0e0a59aac13e43a1f"
+"checksum lalrpop-util 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "60c6c48ba857cd700673ce88907cadcdd7e2cd7783ed02378537c5ffd4f6460c"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
+"checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
+"checksum petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8b30dc85588cd02b9b76f5e386535db546d21dc68506cff2abebee0b6445e8e4"
+"checksum phf_generator 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "05a079dd052e7b674d21cb31cbb6c05efd56a2cd2827db7692e2f1a507ebd998"
+"checksum phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2261d544c2bb6aa3b10022b0be371b9c7c64f762ef28c6f5d4f1ef6d97b5930"
+"checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a45f2f0ae0b5757f6fe9e68745ba25f5246aea3598984ed81d013865873c1f84"
 "checksum pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdf85cda6cadfae5428a54661d431330b312bc767ddbc57adbedc24da66e32"
@@ -565,6 +1001,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "0a12d51a5b5fd700e6c757f15877685bfa04fd7eb60c108f01d045cafa0073c2"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+"checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
+"checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
+"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum rustc-hash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06ddba37baa245040f932b15403071a46681d7e0e4158e230741943c4718b84"
@@ -574,8 +1015,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "2a4d976362a13caad61c38cf841401d2d4d480496a9391c3842c288b01f9de95"
 "checksum serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "94bb618afe46430c6b089e9b111dc5b2fcd3e26a268da0993f6d16bea51c6021"
 "checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
+"checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+"checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
 "checksum skeptic 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4474d6da9593171bcb086890fc344a3a12783cb24e5b141f8a5d0e43561f4b6"
 "checksum streaming-stats 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "dbc32bf233385fb1ae0c4cf13a8dfd11efec71f6a9de95feac8c870788bc8b25"
+"checksum string_cache 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8ae5fbdcafd8573e2bfc14acb54720e27bbf102376ed05d6052f7eb238b27"
+"checksum string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "35293b05cf1494e8ddd042a7df6756bf18d07f42d234f32e71dce8a7aabb0191"
+"checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
+"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b96fc11ba8cf80bfa5cdd6de538c9f7c66f519f83e8caabc554e431bf3e36d"
 "checksum structopt-derive 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "95063e55a45976cfce9f03fcd26dff356ee622f1a14147bfae068ab8bed153a6"
@@ -585,13 +1032,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ structopt = "0.2.8"
 clap = "2.31.2"
 histo = "0.1.0"
 polonius-engine = {version = "0.4.0", path = "polonius-engine" }
+polonius-parser = {version = "0.1.0", path = "polonius-parser" }
 
 [workspace]

--- a/polonius-parser/Cargo.toml
+++ b/polonius-parser/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "polonius-parser"
+version = "0.1.0"
+description = "Parser for the Polonius project"
+license = "Apache-2.0/MIT"
+authors = ["The Rust Project Developers"]
+repository = "https://github.com/rust-lang-nursery/polonius"
+build = "build.rs" # LALRPOP preprocessing
+
+[build-dependencies]
+lalrpop = "0.15.2"
+
+[dependencies]
+lalrpop-util = "0.15.2"
+regex = "1.0.0"

--- a/polonius-parser/build.rs
+++ b/polonius-parser/build.rs
@@ -1,0 +1,5 @@
+extern crate lalrpop;
+
+fn main() {
+    lalrpop::process_root().unwrap();
+}

--- a/polonius-parser/src/ir.rs
+++ b/polonius-parser/src/ir.rs
@@ -1,0 +1,51 @@
+#[derive(Debug)]
+pub struct Input {
+    pub universal_regions: Vec<String>,
+    pub blocks: Vec<Block>,
+}
+
+#[derive(Debug)]
+pub struct Block {
+    pub name: String,
+    pub statements: Vec<Statement>,
+    pub goto: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct Statement {
+    /// Effects destined to be emitted at the Statement's Start point
+    pub effects_start: Vec<Effect>,
+
+    /// Effects destined to be emitted at the Statement's Mid point
+    pub effects: Vec<Effect>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Effect {
+    Use { regions: Vec<String> },
+    Fact(Fact),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Fact {
+    Outlives { a: String, b: String },
+    BorrowRegionAt { region: String, loan: String },
+    Invalidates { loan: String },
+    Kill { loan: String },
+}
+
+impl Statement {
+    crate fn new(effects: Vec<Effect>) -> Self {
+        Self {
+            effects_start: Vec::new(),
+            effects,
+        }
+    }
+
+    crate fn with_start_effects(effects_start: Vec<Effect>, effects: Vec<Effect>) -> Self {
+        Self {
+            effects_start,
+            effects,
+        }
+    }
+}

--- a/polonius-parser/src/lib.rs
+++ b/polonius-parser/src/lib.rs
@@ -1,0 +1,13 @@
+#![feature(crate_in_paths)]
+#![feature(crate_visibility_modifier)]
+
+pub mod ir;
+
+mod parser;
+mod tests;
+
+pub fn parse_input(text: &str) -> Result<ir::Input, String> {
+    parser::InputParser::new()
+        .parse(text)
+        .map_err(|e| format!("Polonius parse error: {:?}", e))
+}

--- a/polonius-parser/src/parser.lalrpop
+++ b/polonius-parser/src/parser.lalrpop
@@ -1,0 +1,64 @@
+use ir::*;
+
+grammar;
+
+pub Input: Input = {
+    Comment* <universal_regions:UniversalRegions> Comment* <blocks:BlockDefn*> => Input { <> }
+};
+
+Comment: () = {
+    r"//.*"
+};
+
+UniversalRegions = "universal_regions" "{" <Comma<Region>> "}";
+BlockDefn : Block = {
+    "block" <name:Block> "{" <statements:Statement*> Comment* <goto:Goto> "}" => Block { <> },
+};
+
+Goto: Vec<String> = {
+    "goto" <Comma<Block>> ";",
+    () => Vec::new(),
+};
+
+Statement : Statement = {
+    Comment* <Effects> ";" => Statement::new(<>),
+    Comment* <start_effects:Effects> "/" <effects:Effects> ";" => Statement::with_start_effects(<>),
+};
+
+Effects = Comma<Effect>;
+Effect = { 
+    <Fact> => Effect::Fact(<>),
+    Use
+};
+
+Fact : Fact = {
+  "outlives" "(" <a:Region> ":" <b:Region> ")" => Fact::Outlives { <> },
+  "borrow_region_at" "(" <region:Region> "," <loan:Loan> ")" => Fact::BorrowRegionAt { <> },
+  "invalidates" "(" <loan:Loan> ")" => Fact::Invalidates { <> },
+  "kill" "(" <loan:Loan> ")" => Fact::Kill { <> },
+};
+
+Use : Effect = "use" "(" <regions:Comma<Region>> ")" => Effect::Use { <> };
+
+Comma<T>: Vec<T> = {
+    <v:(<T> ",")*> <e:T?> => match e {
+        None => v,
+        Some(e) => {
+            let mut v = v;
+            v.push(e);
+            v
+        }
+    }
+};
+
+Region: String = {
+    r"'\w+" => <>.to_string()
+};
+
+Block: String = {
+    r"B\w+" => <>.to_string()
+};
+
+Loan: String = {
+    r"L\w+" => <>.to_string()
+};

--- a/polonius-parser/src/tests.rs
+++ b/polonius-parser/src/tests.rs
@@ -1,0 +1,200 @@
+#![cfg(test)]
+
+use crate::ir::{Effect, Fact};
+use crate::parse_input;
+
+#[test]
+fn universal_regions() {
+    let program = r"
+        universal_regions { 'a, 'b, 'c }
+    ";
+    let input = parse_input(program);
+    assert!(input.is_ok());
+
+    let input = input.unwrap();
+    assert_eq!(input.universal_regions, ["'a", "'b", "'c"]);
+}
+
+#[test]
+fn blocks() {
+    let program = r"
+        universal_regions { 'a, 'b, 'c }
+        block B0 {
+        }
+        block B1 {
+        }
+    ";
+    let input = parse_input(program);
+    assert!(input.is_ok());
+
+    let input = input.unwrap();
+    assert_eq!(
+        input.blocks.iter().map(|b| &b.name).collect::<Vec<_>>(),
+        ["B0", "B1"]
+    );
+}
+
+#[test]
+fn goto() {
+    let program = r"
+        universal_regions { 'a, 'b, 'c }
+        block B0 {
+            goto B1;
+        }
+        block B1 {
+        }
+    ";
+    let input = parse_input(program);
+    assert!(input.is_ok());
+
+    let input = input.unwrap();
+    assert_eq!(input.blocks[0].goto, ["B1"]);
+}
+
+#[test]
+fn effects() {
+    let program = r"
+        universal_regions { 'a, 'b, 'c }
+        block B0 {
+            use('a), outlives('a: 'b), borrow_region_at('b, L1);
+            kill(L2);
+            invalidates(L0);
+        }
+    ";
+    let input = parse_input(program);
+    assert!(input.is_ok());
+
+    let input = input.unwrap();
+    let block = &input.blocks[0];
+    assert_eq!(block.statements.len(), 3);
+
+    let statements = &block.statements;
+    assert_eq!(statements[0].effects.len(), 3);
+    assert_eq!(statements[1].effects.len(), 1);
+    assert_eq!(statements[2].effects.len(), 1);
+
+    let effects = &statements[0].effects;
+    assert_eq!(
+        effects[0],
+        Effect::Use {
+            regions: vec!["'a".to_string()]
+        }
+    );
+    assert_eq!(
+        effects[1],
+        Effect::Fact(Fact::Outlives {
+            a: "'a".to_string(),
+            b: "'b".to_string()
+        })
+    );
+    assert_eq!(
+        effects[2],
+        Effect::Fact(Fact::BorrowRegionAt {
+            region: "'b".to_string(),
+            loan: "L1".to_string()
+        })
+    );
+
+    let effects = &statements[1].effects;
+    assert_eq!(
+        effects[0],
+        Effect::Fact(Fact::Kill {
+            loan: "L2".to_string()
+        })
+    );
+
+    let effects = &statements[2].effects;
+    assert_eq!(
+        effects[0],
+        Effect::Fact(Fact::Invalidates {
+            loan: "L0".to_string()
+        })
+    );
+}
+
+#[test]
+fn effects_start() {
+    let program = r"
+        universal_regions { 'a, 'b, 'c }
+        block B0 {
+            invalidates(L0) / use('a);
+            invalidates(L1);
+            invalidates(L0), invalidates(L1) / use('c);
+        }
+    ";
+    let input = parse_input(program);
+    assert!(input.is_ok());
+
+    let input = input.unwrap();
+    let block = &input.blocks[0];
+    assert_eq!(block.statements.len(), 3);
+
+    let statements = &block.statements[0];
+    assert_eq!(
+        statements.effects_start,
+        [Effect::Fact(Fact::Invalidates {
+            loan: "L0".to_string()
+        })]
+    );
+    assert_eq!(
+        statements.effects,
+        [Effect::Use {
+            regions: vec!["'a".to_string()]
+        }]
+    );
+
+    let statements = &block.statements[1];
+    assert!(statements.effects_start.is_empty());
+    assert_eq!(
+        statements.effects,
+        [Effect::Fact(Fact::Invalidates {
+            loan: "L1".to_string()
+        })]
+    );
+
+    let statements = &block.statements[2];
+    assert_eq!(
+        statements.effects_start,
+        [
+            Effect::Fact(Fact::Invalidates {
+                loan: "L0".to_string()
+            }),
+            Effect::Fact(Fact::Invalidates {
+                loan: "L1".to_string()
+            })
+        ]
+    );
+    assert_eq!(
+        statements.effects,
+        [Effect::Use {
+            regions: vec!["'c".to_string()]
+        }]
+    );
+}
+
+#[test]
+fn complete_example() {
+    let program = r"
+        // program description
+        universal_regions { 'a, 'b, 'c }
+
+        // block description
+        block B0 {
+            // 0:
+            invalidates(L0);
+
+            // 1:
+            kill(L2);
+
+            invalidates(L1) / use('a, 'b);
+
+            // another comment
+            goto B1, B2;
+        }
+
+        block B1 {
+            use('a), outlives('a: 'b), borrow_region_at('b, L1);
+        }
+    ";
+    assert!(parse_input(program).is_ok());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate datafrog;
 extern crate failure;
 extern crate histo;
 extern crate polonius_engine;
+extern crate polonius_parser;
 extern crate rustc_hash;
 extern crate structopt;
 
@@ -19,6 +20,7 @@ extern crate clap;
 mod dump;
 mod facts;
 mod intern;
+mod program;
 mod tab_delim;
 mod test;
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,0 +1,335 @@
+use std::collections::BTreeSet;
+
+use polonius_parser::{
+    ir::{Effect, Fact}, parse_input,
+};
+
+use crate::facts::{AllFacts, Loan, Point, Region};
+use crate::intern::InternerTables;
+
+/// A structure to hold and deduplicate facts
+#[derive(Default)]
+struct Facts {
+    borrow_region: BTreeSet<(Region, Loan, Point)>,
+    universal_region: BTreeSet<Region>,
+    cfg_edge: BTreeSet<(Point, Point)>,
+    killed: BTreeSet<(Loan, Point)>,
+    outlives: BTreeSet<(Region, Region, Point)>,
+    region_live_at: BTreeSet<(Region, Point)>,
+    invalidates: BTreeSet<(Point, Loan)>,
+}
+
+impl From<Facts> for AllFacts {
+    fn from(facts: Facts) -> Self {
+        Self {
+            borrow_region: facts.borrow_region.into_iter().collect(),
+            universal_region: facts.universal_region.into_iter().collect(),
+            cfg_edge: facts.cfg_edge.into_iter().collect(),
+            killed: facts.killed.into_iter().collect(),
+            outlives: facts.outlives.into_iter().collect(),
+            region_live_at: facts.region_live_at.into_iter().collect(),
+            invalidates: facts.invalidates.into_iter().collect(),
+        }
+    }
+}
+
+/// Parses an input program into a set of its facts, into the same format `rustc` outputs.
+crate fn parse_from_program(
+    program: &str,
+    tables: &mut InternerTables,
+) -> Result<AllFacts, String> {
+    let input = parse_input(program)?;
+
+    let mut facts: Facts = Default::default();
+
+    // facts: universal_region(Region)
+    for region in &input.universal_regions {
+        let region = tables.regions.intern(region);
+        facts.universal_region.insert(region);
+    }
+
+    for block in &input.blocks {
+        let block_name = &block.name;
+
+        for (statement_idx, statement) in block.statements.iter().enumerate() {
+            let start = format!(
+                "\"Start({block}[{statement}])\"",
+                block = block_name,
+                statement = statement_idx
+            );
+            let mid = format!(
+                "\"Mid({block}[{statement}])\"",
+                block = block_name,
+                statement = statement_idx
+            );
+
+            let start = tables.points.intern(&start);
+            let mid = tables.points.intern(&mid);
+
+            // facts: cfg_edge(Point, Point)
+            {
+                if statement_idx > 0 {
+                    // edge: Previous Mid point to this Start point
+                    let previous_mid = format!(
+                        "\"Mid({block}[{previous_statement}])\"",
+                        block = block_name,
+                        previous_statement = statement_idx - 1
+                    );
+                    let previous_mid = tables.points.intern(&previous_mid);
+
+                    facts.cfg_edge.insert((previous_mid, start));
+                }
+
+                // edge: Start to Mid point
+                facts.cfg_edge.insert((start, mid));
+
+                // goto edges
+                let terminator_idx = block.statements.len() - 1;
+                for goto in &block.goto {
+                    // edge: last Mid point to Start of remote block
+                    let from = format!(
+                        "\"Mid({block}[{statement}])\"",
+                        block = block_name,
+                        statement = terminator_idx
+                    );
+                    let to = format!("\"Start({next_block}[0])\"", next_block = goto);
+
+                    let from = tables.points.intern(&from);
+                    let to = tables.points.intern(&to);
+
+                    facts.cfg_edge.insert((from, to));
+                }
+            }
+
+            // the most common statement effects: mid point effects
+            for effect in &statement.effects {
+                match effect {
+                    Effect::Use { ref regions } => {
+                        // Uses.
+                        // TODO: Incomplete. We should eventually compute liveness
+                        // in order to emit `region_live_at` facts at all correct computed points,
+                        // and not just at the manually specified statements' Start point.
+                        //
+                        // facts: region_live_at(Region, Point)
+                        // region_live_at: a `use` emits a `region_live_at` the Start point
+                        for region in regions {
+                            let region = tables.regions.intern(region);
+                            facts.region_live_at.insert((region, start));
+                        }
+                    }
+
+                    Effect::Fact(ref fact) => {
+                        // Manually specified facts
+                        emit_fact(&mut facts, fact, mid, tables)
+                    }
+                };
+            }
+
+            // commonly used to emit manual `invalidates` at Start points, like some rustc features do
+            for effect in &statement.effects_start {
+                if let Effect::Fact(ref fact) = effect {
+                    emit_fact(&mut facts, fact, start, tables);
+                }
+            }
+        }
+    }
+
+    Ok(facts.into())
+}
+
+fn emit_fact(facts: &mut Facts, fact: &Fact, point: Point, tables: &mut InternerTables) {
+    match fact {
+        // facts: borrow_region(Region, Loan, Point)
+        Fact::BorrowRegionAt {
+            ref region,
+            ref loan,
+        } => {
+            // borrow_region: a `borrow_region_at` occurs on the Mid point
+            let region = tables.regions.intern(region);
+            let loan = tables.loans.intern(loan);
+
+            facts.borrow_region.insert((region, loan, point));
+        }
+
+        // facts: outlives(Region, Region, Point)
+        Fact::Outlives { ref a, ref b } => {
+            // outlives: a `outlives` occurs on Mid points
+            let region_a = tables.regions.intern(a);
+            let region_b = tables.regions.intern(b);
+
+            facts.outlives.insert((region_a, region_b, point));
+        }
+
+        // facts: killed(Loan, Point)
+        Fact::Kill { ref loan } => {
+            // killed: a loan is killed on Mid points
+            let loan = tables.loans.intern(loan);
+            facts.killed.insert((loan, point));
+        }
+
+        // facts: invalidates(Point, Loan)
+        Fact::Invalidates { ref loan } => {
+            let loan = tables.loans.intern(loan);
+            // invalides: a loan can be invalidated on both Start and Mid points
+            facts.invalidates.insert((point, loan));
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intern::InternerTables;
+
+    #[test]
+    fn complete_program() {
+        let program = r"
+            // program description
+            universal_regions { 'a, 'b, 'c }
+
+            // block description
+            block B0 {
+                // 0:
+                invalidates(L0);
+
+                // 1:
+                invalidates(L1) / kill(L2);
+
+                // another comment
+                goto B1;
+            }
+
+            block B1 {
+                // O:
+                use('a, 'b), outlives('a: 'b), borrow_region_at('b, L1);
+            }
+        ";
+
+        let mut tables = InternerTables::new();
+
+        let facts = parse_from_program(program, &mut tables);
+        assert!(facts.is_ok());
+
+        let facts = facts.unwrap();
+
+        // facts: universal_region
+        let universal_regions: Vec<_> = facts
+            .universal_region
+            .iter()
+            .map(|r| tables.regions.untern(*r).to_string())
+            .collect();
+        assert_eq!(universal_regions, ["'a", "'b", "'c"]);
+
+        // facts: invalidates
+        assert_eq!(facts.invalidates.len(), 2);
+        {
+            // regular mid point `invalidates`
+            let point = tables.points.untern(facts.invalidates[0].0);
+            let loan = tables.loans.untern(facts.invalidates[0].1);
+
+            assert_eq!(point, "\"Mid(B0[0])\"");
+            assert_eq!(loan, "L0");
+        }
+
+        {
+            // uncommon start point `invalidates`
+            let point = tables.points.untern(facts.invalidates[1].0);
+            let loan = tables.loans.untern(facts.invalidates[1].1);
+
+            assert_eq!(point, "\"Start(B0[1])\"");
+            assert_eq!(loan, "L1");
+        }
+
+        // TODO: incomplete until either all the `region_live_at` are computed with liveness,
+        // or they are emitted manually at Start points.
+        // facts: region_live_at
+        assert_eq!(facts.region_live_at.len(), 2);
+        {
+            let region = tables.regions.untern(facts.region_live_at[0].0);
+            let point = tables.points.untern(facts.region_live_at[0].1);
+
+            assert_eq!(region, "'a");
+            assert_eq!(point, "\"Start(B1[0])\"");
+
+            let region = tables.regions.untern(facts.region_live_at[1].0);
+            let point = tables.points.untern(facts.region_live_at[1].1);
+
+            assert_eq!(region, "'b");
+            assert_eq!(point, "\"Start(B1[0])\"");
+        }
+
+        assert_eq!(facts.outlives.len(), 1);
+        {
+            let region_a = tables.regions.untern(facts.outlives[0].0);
+            let region_b = tables.regions.untern(facts.outlives[0].1);
+            let point = tables.points.untern(facts.outlives[0].2);
+
+            assert_eq!(region_a, "'a");
+            assert_eq!(region_b, "'b");
+            assert_eq!(point, "\"Mid(B1[0])\"");
+        }
+
+        assert_eq!(facts.borrow_region.len(), 1);
+        {
+            let region = tables.regions.untern(facts.borrow_region[0].0);
+            let loan = tables.loans.untern(facts.borrow_region[0].1);
+            let point = tables.points.untern(facts.borrow_region[0].2);
+
+            assert_eq!(region, "'b");
+            assert_eq!(loan, "L1");
+            assert_eq!(point, "\"Mid(B1[0])\"");
+        }
+
+        assert_eq!(facts.killed.len(), 1);
+        {
+            let loan = tables.loans.untern(facts.killed[0].0);
+            let point = tables.points.untern(facts.killed[0].1);
+
+            assert_eq!(loan, "L2");
+            assert_eq!(point, "\"Mid(B0[1])\"");
+        }
+
+        // 6 points (3 statements * 2 points) => 5 edges, including the 1 goto edge
+        let points: BTreeSet<Point> = facts
+            .cfg_edge
+            .iter()
+            .map(|&(p, _)| p)
+            .chain(facts.cfg_edge.iter().map(|&(_, q)| q))
+            .collect();
+        assert_eq!(points.len(), 6);
+        assert_eq!(facts.cfg_edge.len(), 5);
+
+        let mut make_edge = |a, b| (tables.points.intern(a), tables.points.intern(b));
+
+        // Start to Mid edge, per statement
+        assert!(
+            facts
+                .cfg_edge
+                .contains(&make_edge("\"Start(B0[0])\"", "\"Mid(B0[0])\""))
+        );
+        assert!(
+            facts
+                .cfg_edge
+                .contains(&make_edge("\"Start(B0[1])\"", "\"Mid(B0[1])\""))
+        );
+        assert!(
+            facts
+                .cfg_edge
+                .contains(&make_edge("\"Start(B1[0])\"", "\"Mid(B1[0])\""))
+        );
+
+        // Mid to Start edge, per statement pair for each block
+        assert!(
+            facts
+                .cfg_edge
+                .contains(&make_edge("\"Mid(B0[0])\"", "\"Start(B0[1])\""))
+        );
+
+        // 1 goto edge from B0 to B1
+        assert!(
+            facts
+                .cfg_edge
+                .contains(&make_edge("\"Mid(B0[1])\"", "\"Start(B1[0])\""))
+        );
+    }
+}


### PR DESCRIPTION
Implement the friendlier front-end format described in issue #26 — destined to help create isolated tests without needing rustc NLL facts, but still generating the same data structure.

Still incomplete regarding `use`, which might require `def`, and also that polonius compute liveness, to correctly emit `region_live_at` points. I'll open an issue for those specific points after this lands.

Here's how it looks:
```
// program description
universal_regions { 'a, 'b, 'c }

// block description
block B0 {
    // effects are by default emitted on the Mid point
    invalidates(L0);

    // but we can still emit some at the Start point if needed
    // by separating the Start point effects from the Mid point effects with a "/"
    invalidates(L1) / kill(L2);

    goto B1;
}
block B1 {
    use('a, 'b), outlives('a: 'b), borrow_region_at('b, L1);
}
```

(Sorry about opening another PR, Github prevents reopening a PR in cases of force push, which I did for the rebases)

Note: This doesn't implement the requirements for the liveness computation described here https://github.com/rust-lang-nursery/polonius/pull/45#discussion_r190516035 