### PR TITLE
Add debug visualization using graphviz

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ This will generate a bunch of output tuples:
 ...
 ```
 
+To generate a [graphviz](https://www.graphviz.org) file with the CFG enriched
+with input and output tuples at each point, do:
+
+```bash
+cargo +nightly run --release --graphviz_file=graph.dot -- inputs/issue-47680/nll-facts/main
+```
+
 ### Want to see something slow?
 
 One of the goals with this repo is to experiment and compare different

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use crate::facts::{Loan, Point, Region};
 use crate::intern;
 use crate::tab_delim;
 use failure::Error;
-use polonius_engine::{Algorithm, Output};
+use polonius_engine::{Algorithm, AllFacts, Output};
 use std::path::Path;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
@@ -44,6 +44,8 @@ pub struct Opt {
     skip_timing: bool,
     #[structopt(short = "v")]
     verbose: bool,
+    #[structopt(long = "graphviz_file")]
+    graphviz_file: Option<String>,
     #[structopt(short = "o", long = "output")]
     output_directory: Option<String>,
     #[structopt(raw(required = "true"))]
@@ -53,19 +55,23 @@ pub struct Opt {
 pub fn main(opt: Opt) -> Result<(), Error> {
     do catch {
         let output_directory = opt.output_directory.map(|x| Path::new(&x).to_owned());
+        let graphviz_file = opt.graphviz_file.map(|x| Path::new(&x).to_owned());
         for facts_dir in opt.fact_dirs {
             let tables = &mut intern::InternerTables::new();
 
-            let result: Result<(Duration, Output<Region, Loan, Point>), Error> = do catch {
+            let result: Result<(Duration, AllFacts<Region, Loan, Point>, Output<Region, Loan, Point>), Error> = do catch {
                 let verbose = opt.verbose;
                 let all_facts =
                     tab_delim::load_tab_delimited_facts(tables, &Path::new(&facts_dir))?;
                 let algorithm = opt.algorithm.into();
-                timed(|| Output::compute(&all_facts, algorithm, verbose))
+                let graphviz_output = graphviz_file.is_some();
+                let (duration, output) =
+                    timed(|| Output::compute(&all_facts, algorithm, verbose || graphviz_output));
+                (duration, all_facts, output)
             };
 
             match result {
-                Ok((duration, output)) => {
+                Ok((duration, all_facts, output)) => {
                     println!("--------------------------------------------------");
                     println!("Directory: {}", facts_dir);
                     if !opt.skip_timing {
@@ -76,6 +82,10 @@ pub fn main(opt: Opt) -> Result<(), Error> {
                     if !opt.skip_tuples {
                         dump::dump_output(&output, &output_directory, tables)
                             .expect("Failed to write output");
+                    }
+                    if let Some(ref graphviz_file) = graphviz_file {
+                        dump::graphviz(&output, &all_facts, graphviz_file, tables)
+                            .expect("Failed to write GraphViz");
                     }
                 }
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,12 +1,14 @@
 use crate::facts::*;
 use crate::intern::InternerTables;
 use crate::intern::*;
-use polonius_engine::Output;
+use polonius_engine::{Output, Atom as PoloniusEngineAtom};
 use rustc_hash::FxHashMap;
 use std::collections::{BTreeMap, BTreeSet};
 use std::hash::Hash;
 use std::io::{self, Write};
+use std::fs::File;
 use std::path::PathBuf;
+use std::collections::HashMap;
 
 crate fn dump_output(
     output: &Output<Region, Loan, Point>,
@@ -218,6 +220,43 @@ impl<T: Atom> OutputDump for T {
     }
 }
 
+impl<T1: Atom> OutputDump for (T1,) {
+    fn push_all(
+        &'a self,
+        intern: &'a InternerTables,
+        prefix: &mut Vec<&'a str>,
+        output: &mut Vec<Vec<&'a str>>,
+    ) {
+        let (ref a1,) = self;
+        let t1_table = T1::table(intern);
+        let a1_text = t1_table.untern(*a1);
+        preserve(prefix, |prefix| {
+            prefix.push(a1_text);
+            output.push(prefix.clone());
+        });
+    }
+}
+
+impl<T1: Atom, T2: Atom> OutputDump for (T1, T2) {
+    fn push_all(
+        &'a self,
+        intern: &'a InternerTables,
+        prefix: &mut Vec<&'a str>,
+        output: &mut Vec<Vec<&'a str>>,
+    ) {
+        let (ref a1, ref a2) = self;
+        let t1_table = T1::table(intern);
+        let t2_table = T2::table(intern);
+        let a1_text = t1_table.untern(*a1);
+        let a2_text = t2_table.untern(*a2);
+        preserve(prefix, |prefix| {
+            prefix.push(a1_text);
+            prefix.push(a2_text);
+            output.push(prefix.clone());
+        });
+    }
+}
+
 fn preserve<'a>(s: &mut Vec<&'a str>, op: impl FnOnce(&mut Vec<&'a str>)) {
     let len = s.len();
     op(s);
@@ -245,3 +284,184 @@ impl Atom for Loan {
         &intern.loans
     }
 }
+
+fn facts_by_point<F: Clone, Out: OutputDump>(facts: impl Iterator<Item=F>, point: impl Fn(F)->(Point, Out), name: String, point_pos: usize, intern: &InternerTables) -> HashMap<Point, String> {
+    let mut by_point: HashMap<Point, Vec<Out>> = HashMap::new();
+    for f in facts {
+        let (p, o) = point(f);
+        by_point.entry(p).or_insert_with(Vec::new).push(o);
+    }
+    by_point.into_iter()
+        .map(|(p, o)| {
+            let mut rows: Vec<Vec<&str>> = Vec::new(); 
+            OutputDump::push_all(&o, intern, &mut vec![], &mut rows);
+            let s = rows.into_iter().map(|mut vals| {
+                vals.insert(point_pos, "_");
+                escape_for_graphviz(format!("{}({})", name,
+                    vals.into_iter().map(|x| x.to_string()).collect::<Vec<_>>().join(", ")).as_str())
+            }).collect::<Vec<_>>().join("\\l") + "\\l";
+            // in graphviz, \l is a \n that left-aligns
+            (p, s)
+        }).collect()
+}
+
+fn build_inputs_by_point_for_visualization(
+    all_facts: &AllFacts,
+    intern: &InternerTables
+) -> Vec<HashMap<Point, String>>  {
+    vec![
+        facts_by_point(
+            all_facts.borrow_region.iter().cloned(),
+            |(a, b, p)| (p, (a, b)),
+            "borrow_region".to_string(),
+            2,
+            intern),
+        facts_by_point(
+            all_facts.killed.iter().cloned(),
+            |(l, p)| (p, (l,)),
+            "killed".to_string(),
+            1,
+            intern),
+        facts_by_point(
+            all_facts.outlives.iter().cloned(),
+            |(r1, r2, p)| (p, (r1, r2)),
+            "outlives".to_string(),
+            2,
+            intern),
+        facts_by_point(
+            all_facts.region_live_at.iter().cloned(),
+            |(r, p)| (p, (r,)),
+            "region_live_at".to_string(),
+            1,
+            intern),
+        facts_by_point(
+            all_facts.invalidates.iter().cloned(),
+            |(p, l)| (p, (l,)),
+            "invalidates".to_string(),
+            0,
+            intern),
+    ]
+}
+
+fn build_outputs_by_point_for_visualization(
+    output: &Output<Region, Loan, Point>,
+    intern: &InternerTables
+) -> Vec<HashMap<Point, String>> {
+    vec![
+        facts_by_point(
+            output.borrow_live_at.iter(),
+            |(pt, loans)| (*pt, loans.clone()),
+            "borrow_live_at".to_string(),
+            0,
+            intern
+        ),
+        facts_by_point(
+            output.restricts.iter(),
+            |(pt, region_to_loans)| (*pt, region_to_loans.clone()),
+            "restricts".to_string(),
+            0,
+            intern
+        ),
+        facts_by_point(
+            output.invalidates.iter(),
+            |(pt, loans)| (*pt, loans.clone()),
+            "invalidates".to_string(),
+            0,
+            intern
+        ),
+        facts_by_point(
+            output.subset.iter(),
+            |(pt, region_to_regions)| (*pt, region_to_regions.clone()),
+            "subset".to_string(),
+            0,
+            intern
+        ),
+    ]
+}
+
+crate fn graphviz(
+    output: &Output<Region, Loan, Point>,
+    all_facts: &AllFacts,
+    output_file: &PathBuf,
+    intern: &InternerTables
+) -> io::Result<()> {
+    let mut file = File::create(output_file)?;
+    let mut output_fragments: Vec<String> = Vec::new();
+    let mut seen_nodes = BTreeSet::new();
+
+    let inputs_by_point = build_inputs_by_point_for_visualization(all_facts, intern);
+    let outputs_by_point = build_outputs_by_point_for_visualization(output, intern);
+
+
+    output_fragments.push("digraph g {\n  graph [\n  rankdir = \"TD\"\n];\n".to_string());
+    for (idx, &(p1, p2)) in all_facts.cfg_edge.iter().enumerate() {
+        let graphviz_code = graphviz_for_edge(p1, p2, idx, &mut seen_nodes,
+                                              &inputs_by_point, &outputs_by_point, intern)
+                                .into_iter();
+        output_fragments.extend(graphviz_code);
+    }
+    output_fragments.push("}".to_string()); // close digraph
+    let output_bytes = output_fragments.join("").bytes().collect::<Vec<_>>();
+    file.write_all(&output_bytes)?;
+    Ok(())
+}
+
+fn graphviz_for_edge(p1: Point, p2: Point, edge_index: usize,
+                     seen_points: &mut BTreeSet<usize>,
+                     inputs_by_point: &Vec<HashMap<Point, String>>,
+                     outputs_by_point: &Vec<HashMap<Point, String>>,
+                     intern: &InternerTables)
+        -> Vec<String> {
+    let mut ret = Vec::new();
+    maybe_render_point(p1, seen_points, inputs_by_point, outputs_by_point,
+                       &mut ret, intern);
+    maybe_render_point(p2, seen_points, inputs_by_point, outputs_by_point,
+                       &mut ret, intern);
+    ret.push(format!("\"node{0}\" -> \"node{1}\":f0 [\n  id = {2}\n];\n",
+                        p1.index(), p2.index(), edge_index));
+    ret
+}
+
+fn maybe_render_point(pt: Point,
+                      seen_points: &mut BTreeSet<usize>,
+                      inputs_by_point: &Vec<HashMap<Point, String>>,
+                      outputs_by_point: &Vec<HashMap<Point, String>>,
+                      render_vec: &mut Vec<String>,
+                      intern: &InternerTables) {
+
+    if seen_points.contains(&pt.index()) {
+        return;
+    }
+    seen_points.insert(pt.index());
+
+    let input_tuples = inputs_by_point.iter().filter_map(|inp| {
+        inp.get(&pt).map(|s| s.to_string())
+    }).collect::<Vec<_>>().join(" | ");
+
+    let output_tuples = outputs_by_point.iter().filter_map(|outp| {
+        outp.get(&pt).map(|s| s.to_string())
+    }).collect::<Vec<_>>().join(" | ");
+
+    render_vec.push(format!("\"node{0}\" [\n  label = \"{{ <f0> {1} | INPUTS | {2} | OUTPUTS | {3} }}\"\n  shape = \"record\"\n];\n",
+                     pt.index(),
+                     escape_for_graphviz(Point::table(intern).untern(pt)),
+                     &input_tuples,
+                     &output_tuples));
+}
+
+fn write_string(f: &mut File, s: &str) -> io::Result<()> {
+    f.write_all(&s.bytes().collect::<Vec<_>>())?;
+    Ok(())
+}
+
+fn escape_for_graphviz(s: &str) -> String {
+     s.replace(r"\", r"\\")
+      .replace("\"", "\\\"")
+      .replace(r"(", r"\(")
+      .replace(r")", r"\)")
+      .replace("\n", r"\n")
+      .to_string()
+}
+
+
+


### PR DESCRIPTION
Co-authored with @yati-sagade at the Rust Impl Days in Paris.

When the --graphviz_file=FILE is given (regardless of -v), we output
a DOT description of the CFG enriched with input and output tuples at
each point.

The code currently writes raw DOT and is likely to break when we need to
output labels that are not escaped for DOT. In that case, it is probably
an idea to use a graphviz crate.

Example usage:

    $ cargo +nightly run --release -- --graphviz_file=graph.dot inputs/issue-47680/nll-facts/main
    $ dot -o graph.svg -Tsvg graph.dot

Fixes #12

Co-authored-by: Yati Sagade <mail@ysagade.nl>
Co-authored-by: Andrea Lattuada <andrea.lattuada@inf.ethz.ch>