### PR TITLE
 Implemented comparing Naive and DatafrogOpt algorithms. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,18 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "env_logger"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "environment"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +312,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "streaming-stats 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "humantime"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -391,6 +411,14 @@ version = "0.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "log"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,8 +469,10 @@ dependencies = [
  "assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "datafrog 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "histo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "polonius-engine 0.4.0",
  "polonius-parser 0.1.0",
  "rustc-hash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -454,6 +484,7 @@ name = "polonius-engine"
 version = "0.4.0"
 dependencies = [
  "datafrog 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -494,6 +525,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -814,6 +850,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +978,14 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "wincolor"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -965,6 +1017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe5a5078ac8c506d3e4430763b1ba9b609b1286913e7d08e581d1c2de9b7e5"
+"checksum env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0e6e40ebb0e66918a37b38c7acab4e10d299e0463fe2af5d29b9cc86710cfd2a"
 "checksum environment 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
@@ -976,6 +1029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum histo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a4195184b16b1e8e50353b41f83ad743b80d687b4c41a6f1d0d50231325e258"
+"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -985,6 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
+"checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
@@ -995,6 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a45f2f0ae0b5757f6fe9e68745ba25f5246aea3598984ed81d013865873c1f84"
 "checksum pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdf85cda6cadfae5428a54661d431330b312bc767ddbc57adbedc24da66e32"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e53eeda07ddbd8b057dde66d9beded11d0dfda13f0db0769e6b71d6bcf2074e"
@@ -1033,6 +1089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
+"checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
@@ -1052,3 +1109,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ keywords = ["compiler", "borrowck", "datalog"]
 assert_cli = "0.5.4"
 
 [dependencies]
+log = "0.4"
+env_logger = "0.5"
 datafrog = "0.1.0"
 failure = "0.1.1"
 rustc-hash = "1.0.0"

--- a/polonius-engine/Cargo.toml
+++ b/polonius-engine/Cargo.toml
@@ -11,3 +11,4 @@ keywords = ["compiler", "borrowck", "datalog"]
 [dependencies]
 datafrog = "0.1.0"
 rustc-hash = "1.0.0"
+log = "0.4"

--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -1,4 +1,5 @@
 use std::hash::Hash;
+use std::fmt::Debug;
 
 /// The "facts" which are the basis of the NLL borrow analysis.
 #[derive(Clone)]
@@ -41,6 +42,6 @@ impl<R: Atom, L: Atom, P: Atom> Default for AllFacts<R, L, P> {
     }
 }
 
-pub trait Atom: From<usize> + Into<usize> + Copy + Clone + Eq + Ord + Hash + 'static {
+pub trait Atom: From<usize> + Into<usize> + Copy + Clone + Debug + Eq + Ord + Hash + 'static {
     fn index(self) -> usize;
 }

--- a/polonius-engine/src/lib.rs
+++ b/polonius-engine/src/lib.rs
@@ -3,6 +3,8 @@
 /// Contains the core of the Polonius borrow checking engine.
 /// Input is fed in via AllFacts, and outputs are returned via Output
 extern crate datafrog;
+#[macro_use]
+extern crate log;
 extern crate rustc_hash;
 
 mod facts;

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -24,6 +24,30 @@ pub enum Algorithm {
     LocationInsensitive,
 }
 
+impl Algorithm {
+    pub fn variants() -> [&'static str; 3] {
+        ["Naive", "DatafrogOpt", "LocationInsensitive"]
+    }
+}
+
+impl ::std::str::FromStr for Algorithm {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Naive" | _ if s.eq_ignore_ascii_case("Naive") => Ok(Algorithm::Naive),
+            "DatafrogOpt" | _ if s.eq_ignore_ascii_case("DatafrogOpt") => {
+                Ok(Algorithm::DatafrogOpt)
+            }
+            "LocationInsensitive" | _ if s.eq_ignore_ascii_case("LocationInsensitive") => {
+                Ok(Algorithm::LocationInsensitive)
+            }
+            _ => Err(String::from(
+                "valid values: Naive, DatafrogOpt, LocationInsensitive",
+            )),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Output<Region: Atom, Loan: Atom, Point: Atom> {
     pub borrow_live_at: FxHashMap<Point, Vec<Loan>>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,7 @@ use structopt::StructOpt;
 pub struct Opt {
     #[structopt(
         short = "a",
+        env = "POLONIUS_ALGORITHM",
         default_value = "naive",
         raw(possible_values = "&Algorithm::variants()", case_insensitive = "true")
     )]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)] // arg_enum! uses deprecated stuff
-
 use crate::dump;
 use crate::facts::{Loan, Point, Region};
 use crate::intern;
@@ -10,34 +8,15 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
 
-arg_enum! {
-    #[derive(Debug, Clone, Copy)]
-    pub enum AlgorithmOpts {
-        Naive,
-        DatafrogOpt,
-        LocationInsensitive,
-    }
-}
-
-impl Into<Algorithm> for AlgorithmOpts {
-    fn into(self) -> Algorithm {
-        match self {
-            AlgorithmOpts::Naive => Algorithm::Naive,
-            AlgorithmOpts::DatafrogOpt => Algorithm::DatafrogOpt,
-            AlgorithmOpts::LocationInsensitive => Algorithm::LocationInsensitive,
-        }
-    }
-}
-
 #[derive(StructOpt, Debug)]
 #[structopt(name = "borrow-check")]
 pub struct Opt {
     #[structopt(
         short = "a",
         default_value = "naive",
-        raw(possible_values = "&AlgorithmOpts::variants()", case_insensitive = "true")
+        raw(possible_values = "&Algorithm::variants()", case_insensitive = "true")
     )]
-    algorithm: AlgorithmOpts,
+    algorithm: Algorithm,
     #[structopt(long = "skip-tuples")]
     skip_tuples: bool,
     #[structopt(long = "skip-timing")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@ extern crate polonius_engine;
 extern crate polonius_parser;
 extern crate rustc_hash;
 extern crate structopt;
-
-#[macro_use]
 extern crate clap;
 
 mod dump;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 extern crate failure;
 extern crate polonius;
 extern crate structopt;
+extern crate env_logger;
 
 use structopt::StructOpt;
 
 pub fn main() -> Result<(), failure::Error> {
+    env_logger::init();
     let opt = polonius::cli::Opt::from_args();
     polonius::cli::main(opt)
 }


### PR DESCRIPTION
Note: this pull request is based on my [previous](https://github.com/rust-lang-nursery/polonius/pull/60) pull request.

Changes:
1. Added a new `Algorithm` “type” `Compare` that runs both `Naive` and `DatafrogOpt` and compares the reported errors. If they differ, reports differences via logging as `error` and panics.
2. I have also added a test for testing the comparison algorithm. However, for some reason, it is not picked up if I run `cargo test` from the root directory.

Example output:
```bash
RUST_LOG=polonius_engine=trace cargo run -- inputs/issue-47680/nll-facts/main -a compare
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/polonius inputs/issue-47680/nll-facts/main -a compare`
DEBUG 2018-05-29T14:12:21Z: polonius_engine::output: Naive and optimized algorithms reported the same errors.
--------------------------------------------------
Directory: inputs/issue-47680/nll-facts/main
Time: 0.030s
# borrow_live_at
```