### PR TITLE
Remove `termination_trait_test` feature attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(crate_visibility_modifier)]
 #![feature(proc_macro)]
 #![feature(in_band_lifetimes)]
-#![feature(termination_trait_test)]
 #![allow(dead_code)]
 
 extern crate datafrog;


### PR DESCRIPTION
The feature is stable since 1.27.0 and no longers require enabling — so it triggers a warning if we keep it.