### PR TITLE
Add macro_use for extern crate structopt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate histo;
 extern crate polonius_engine;
 extern crate polonius_parser;
 extern crate rustc_hash;
+#[macro_use]
 extern crate structopt;
 extern crate clap;
 


### PR DESCRIPTION
Polonius does not compile with the latest nightly rustc:

```
error[E0658]: The attribute `structopt` is currently unknown to the compiler and may have meaning added to it in the future (see issue #29642)
  --> src/cli.rs:27:5
   |
27 |     #[structopt(long = "graphviz_file")]
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(custom_attribute)] to the crate attributes to enable
```

Adding `#[macro_use]` before `extern crate structopt` fixes it.

See also: https://github.com/TeXitoi/structopt/issues/125