### PR TITLE
Remove symmetries in the `subset` relation

### DIFF
--- a/polonius-engine/src/output/datafrog_opt.rs
+++ b/polonius-engine/src/output/datafrog_opt.rs
@@ -109,6 +109,20 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
 
         // .. and then start iterating rules!
         while iteration.changed() {
+            // Cleanup step: remove symmetries
+            // - remove regions which are `subset`s of themselves
+            //
+            // FIXME: investigate whether is there a better way to do that without complicating
+            // the rules too much, because it would also require temporary variables and
+            // impact performance. Until then, the big reduction in tuples improves performance
+            // a lot, even if we're potentially adding a small number of tuples
+            // per round just to remove them in the next round.
+            subset
+                .recent
+                .borrow_mut()
+                .elements
+                .retain(|&(r1, r2, _)| r1 != r2);
+
             // remap fields to re-index by the different keys
             subset_r1p.from_map(&subset, |&(r1, r2, p)| ((r1, p), r2));
             subset_p.from_map(&subset, |&(r1, r2, p)| (p, (r1, r2)));
@@ -319,6 +333,10 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
             }
 
             let subset = subset.complete();
+            assert!(
+                subset.iter().filter(|&(r1, r2, _)| r1 == r2).count() == 0,
+                "unwanted subset symmetries"
+            );
             for (r1, r2, location) in &subset.elements {
                 result
                     .subset


### PR DESCRIPTION
On the clap dataset, there are:
- Naive variant: subset (7 531 526) symmetries: 794 833
Removing the symmetries results: from 36.7s to 33.2s (non-scientific benchmarks, best time)

- DatafrogOpt variant: subset (2 714 121) symmetries: 481 294
Removing the symmetries results: from 5.89s to 5.02s (non-scientific benchmarks, best time)

This could be considered as fixing #62.

r? @nikomatsakis 