### PR TITLE
Remove crate_in_paths feature as it has been stabilized in 1.30

### DIFF
--- a/polonius-engine/src/lib.rs
+++ b/polonius-engine/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(crate_in_paths)]
-
 /// Contains the core of the Polonius borrow checking engine.
 /// Input is fed in via AllFacts, and outputs are returned via Output
 extern crate datafrog;

--- a/polonius-parser/src/lib.rs
+++ b/polonius-parser/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(crate_in_paths)]
 #![feature(crate_visibility_modifier)]
 
 pub mod ir;


### PR DESCRIPTION
Removes the warning in recent nightlies