### PR TITLE
Dead can reach bug fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ dependencies = [
  "assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datafrog 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "histo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dev-dependencies]
 assert_cli = "0.5.4"
+diff = "0.1.0"
 
 [dependencies]
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ particularly egregious case where we currently perform poorly, and you
 can test it against it like so:
 
 ```bash
-> cargo +nightly run --release -- inputs/clap-rs/app-parser-{{impl}}-add_defaults/ | head
+> cargo +nightly run --release -- inputs/clap-rs/app-parser-{{impl}}-add_defaults/
     Finished release [optimized] target(s) in 0.05 secs
      Running `target/release/borrow-check 'inputs/clap-rs/app-parser-{{impl}}-add_defaults/'`
 --------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -35,23 +35,29 @@ with input and output tuples at each point, do:
 cargo +nightly run --release -- --graphviz_file=graph.dot inputs/issue-47680/nll-facts/main
 ```
 
-### Want to see something slow?
+### Want to run the code?
 
 One of the goals with this repo is to experiment and compare different
-implementations of the same algorithm. The repo includes one
-particularly egregious case where we currently perform poorly, and you
-can test it against it like so:
+implementations of the same algorithm. You can run the analysis by using `cargo run`
+and you can choose the analysis with `-a`. So for example to run against an example
+extract from clap, you might do:
 
 ```bash
-> cargo +nightly run --release -- inputs/clap-rs/app-parser-{{impl}}-add_defaults/
+> cargo +nightly run --release -- -a DatafrogOpt inputs/clap-rs/app-parser-{{impl}}-add_defaults/
     Finished release [optimized] target(s) in 0.05 secs
      Running `target/release/borrow-check 'inputs/clap-rs/app-parser-{{impl}}-add_defaults/'`
 --------------------------------------------------
 Directory: inputs/clap-rs/app-parser-{{impl}}-add_defaults/
-Time: 113.316s
+Time: 3.856s
 ```
 
-(You can see it is pretty dang slow on my machine!)
+You could also try `-a Naive` to get the naive rules (more readable, slower)
+or `-a LocationInsensitive` to use a location insensitive analysis.
+
+By default, `cargo run` just prints timing. If you also want to see
+the results, try `--show-tuples` (which will show errors) and maybe
+`-v` (to show more intermediate computations). You can supply `--help`
+to get more docs.
 
 ### How to generate your own inputs
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ This is a core library that models the borrow check. It implements the analysis
 
 [post]: http://smallcultfollowing.com/babysteps/blog/2018/04/27/an-alias-based-formulation-of-the-borrow-checker/
 
+### Why the name "Polonius"?
+
+The name comes from the famous quote ["Neither borrower nor lender
+be"][nblnb], which comes from the character Polonius in Shakespeare's
+*Hamlet*.
+
+[nblnb]: https://literarydevices.net/neither-a-borrower-nor-a-lender-be/
+
 ### How to use
 
 First off, you must use the **nightly** channel. To build, do something like this:

--- a/README.md
+++ b/README.md
@@ -11,38 +11,6 @@ be"][nblnb], which comes from the character Polonius in Shakespeare's
 
 [nblnb]: https://literarydevices.net/neither-a-borrower-nor-a-lender-be/
 
-### How to use
-
-First off, you must use the **nightly** channel. To build, do something like this:
-
-```bash
-cargo +nightly build --release
-```
-
-You can try it on one our input tests like so:
-
-```bash
-cargo +nightly run --release -- inputs/issue-47680/nll-facts/main
-```
-
-This will generate a bunch of output tuples:
-
-```
-# borrow_live_at
-
-"Mid(bb3[2])"   "bw0"
-"Mid(bb3[2])"   "bw2"
-"Mid(bb10[2])"  "bw0"
-...
-```
-
-To generate a [graphviz](https://www.graphviz.org) file with the CFG enriched
-with input and output tuples at each point, do:
-
-```bash
-cargo +nightly run --release -- --graphviz_file=graph.dot inputs/issue-47680/nll-facts/main
-```
-
 ### Want to run the code?
 
 One of the goals with this repo is to experiment and compare different

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Directory: inputs/clap-rs/app-parser-{{impl}}-add_defaults/
 Time: 3.856s
 ```
 
-You could also try `-a Naive` to get the naive rules (more readable, slower)
-or `-a LocationInsensitive` to use a location insensitive analysis.
+You could also try `-a Naive` to get the naive rules (more readable,
+slower) -- these are the exact rules described in [the
+blogpost][post]. You can also use `-a LocationInsensitive` to use a
+location insensitive analysis (faster, but may yield spurious errors).
 
 By default, `cargo run` just prints timing. If you also want to see
 the results, try `--show-tuples` (which will show errors) and maybe

--- a/polonius-engine/src/facts.rs
+++ b/polonius-engine/src/facts.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 use std::fmt::Debug;
 
 /// The "facts" which are the basis of the NLL borrow analysis.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AllFacts<R: Atom, L: Atom, P: Atom> {
     /// `borrow_region(R, B, P)` -- the region R may refer to data
     /// from borrow B starting at the point P (this is usually the

--- a/polonius-engine/src/output/datafrog_opt.rs
+++ b/polonius-engine/src/output/datafrog_opt.rs
@@ -352,8 +352,6 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
                 |&(r2, p), &b| ((r2, p), b),
             );
 
-            // dead_borrow_region_can_reach_live(B, P) :-
-
             // .decl borrow_live_at(B, P) -- true if the restrictions of the borrow B
             // need to be enforced at the point P
             //

--- a/polonius-engine/src/output/datafrog_opt.rs
+++ b/polonius-engine/src/output/datafrog_opt.rs
@@ -91,7 +91,6 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
 
         let dying_can_reach_live =
             iteration.variable::<((Region, Point, Point), Region)>("dying_can_reach_live");
-        let dying_can_reach_live_r1pq = iteration.variable_indistinct("dying_can_reach_live_r1pq");
 
         // output
         let errors = iteration.variable("errors");
@@ -134,8 +133,6 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
                 .from_map(&live_to_dead_regions, |&(r1, r2, p, q)| ((r2, p, q), r1));
 
             dying_can_reach_r2q.from_map(&dying_can_reach, |&(r1, r2, p, q)| ((r2, q), (r1, p)));
-            dying_can_reach_live_r1pq
-                .from_map(&dying_can_reach_live, |&((r1, p, q), r2)| ((r1, p, q), r2));
 
             // it's now time ... to datafrog:
 
@@ -290,7 +287,7 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
             //   dying_can_reach_live(R2, R3, P, Q).
             subset.from_join(
                 &live_to_dead_regions_r2pq,
-                &dying_can_reach_live_r1pq,
+                &dying_can_reach_live,
                 |&(_r2, _p, q), &r1, &r3| (r1, r3, q),
             );
 
@@ -305,7 +302,7 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
             // to `Q`.
             requires.from_join(
                 &dying_region_requires,
-                &dying_can_reach_live_r1pq,
+                &dying_can_reach_live,
                 |&(_r1, _p, q), &b, &r2| (r2, b, q),
             );
 

--- a/polonius-engine/src/output/datafrog_opt.rs
+++ b/polonius-engine/src/output/datafrog_opt.rs
@@ -207,7 +207,7 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
             // dying_can_reach_origins(R2, P, Q) :-
             //   live_to_dying_regions(_, R2, P, Q).
             // dying_can_reach_origins(R, P, Q) :-
-            //   dying_region_requires(R, P, Q, B).
+            //   dying_region_requires(R, P, Q, _B).
             dying_can_reach_origins.from_map(&live_to_dying_regions_r2pq, |&((r2, p, q), _r1)| ((r2, p), q));
             dying_can_reach_origins.from_map(&dying_region_requires, |&((r, p, q), _b)| ((r, p), q));
 

--- a/polonius-engine/src/output/datafrog_opt.rs
+++ b/polonius-engine/src/output/datafrog_opt.rs
@@ -100,7 +100,7 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
             all_facts.region_live_at.iter().map(|&(r, p)| ((r, p), ())),
         ));
         subset.insert(all_facts.outlives.into());
-        requires.insert(all_facts.borrow_region.into());
+        requires.insert(all_facts.borrow_region.clone().into());
 
         // .. and then start iterating rules!
         while iteration.changed() {

--- a/polonius-engine/src/output/datafrog_opt.rs
+++ b/polonius-engine/src/output/datafrog_opt.rs
@@ -364,6 +364,11 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
             //   dead_borrow_region_can_reach_dead(R1, B, P),
             //   subset(R1, R2, P),
             //   region_live_at(R2, P).
+            //
+            // NB: the datafrog code below uses
+            // `dead_borrow_region_can_reach_dead_1`, which is equal
+            // to `dead_borrow_region_can_reach_dead` and `subset`
+            // joined together.
             borrow_live_at.from_join(
                 &dead_borrow_region_can_reach_dead_1,
                 &region_live_at_var,

--- a/polonius-engine/src/output/datafrog_opt.rs
+++ b/polonius-engine/src/output/datafrog_opt.rs
@@ -96,7 +96,7 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
         let dead_borrow_region_can_reach_dead =
             iteration.variable::<((Region, Point), Loan)>("dead_borrow_region_can_reach_dead");
         let dead_borrow_region_can_reach_dead_1 =
-            iteration.variable("dead_borrow_region_can_reach_dead_1");
+            iteration.variable_indistinct("dead_borrow_region_can_reach_dead_1");
 
         // output
         let errors = iteration.variable("errors");

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -27,6 +27,9 @@ pub enum Algorithm {
 }
 
 impl Algorithm {
+    /// Optimized variants that ought to be equivalent to "naive"
+    pub const OPTIMIZED: &'static [Algorithm] = &[Algorithm::DatafrogOpt];
+
     pub fn variants() -> [&'static str; 4] {
         ["Naive", "DatafrogOpt", "LocationInsensitive", "Compare"]
     }

--- a/polonius-engine/src/output/mod.rs
+++ b/polonius-engine/src/output/mod.rs
@@ -52,16 +52,16 @@ impl ::std::str::FromStr for Algorithm {
 
 #[derive(Clone, Debug)]
 pub struct Output<Region: Atom, Loan: Atom, Point: Atom> {
-    pub borrow_live_at: FxHashMap<Point, Vec<Loan>>,
+    pub errors: FxHashMap<Point, Vec<Loan>>,
 
     pub dump_enabled: bool,
 
     // these are just for debugging
+    pub borrow_live_at: FxHashMap<Point, Vec<Loan>>,
     pub restricts: FxHashMap<Point, BTreeMap<Region, BTreeSet<Loan>>>,
     pub restricts_anywhere: FxHashMap<Region, BTreeSet<Loan>>,
     pub region_live_at: FxHashMap<Point, Vec<Region>>,
     pub invalidates: FxHashMap<Point, Vec<Loan>>,
-    pub errors: FxHashMap<Point, Vec<Loan>>,
     pub subset: FxHashMap<Point, BTreeMap<Region, BTreeSet<Region>>>,
     pub subset_anywhere: FxHashMap<Region, BTreeSet<Region>>,
 }

--- a/polonius-engine/src/output/naive.rs
+++ b/polonius-engine/src/output/naive.rs
@@ -181,6 +181,15 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
                     .or_insert(vec![])
                     .push(*region);
             }
+
+            let borrow_live_at = borrow_live_at.complete();
+            for &((loan, location), ()) in &borrow_live_at.elements {
+                result
+                    .borrow_live_at
+                    .entry(location)
+                    .or_insert(Vec::new())
+                    .push(loan);
+            }
         }
 
         errors.complete()

--- a/polonius-engine/src/output/naive.rs
+++ b/polonius-engine/src/output/naive.rs
@@ -37,16 +37,19 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
 
     let mut result = Output::new(dump_enabled);
 
-    let borrow_live_at_start = Instant::now();
+    let computation_start = Instant::now();
 
-    let borrow_live_at = {
+    let errors = {
         // Create a new iteration context, ...
         let mut iteration = Iteration::new();
 
         // .. some variables, ..
         let subset = iteration.variable::<(Region, Region, Point)>("subset");
         let requires = iteration.variable::<(Region, Loan, Point)>("requires");
-        let borrow_live_at = iteration.variable::<(Loan, Point)>("borrow_live_at");
+        let borrow_live_at = iteration.variable::<((Loan, Point), ())>("borrow_live_at");
+
+        // `invalidates` facts, stored ready for joins
+        let invalidates = iteration.variable::<((Loan, Point), ())>("invalidates");
 
         // different indices for `subset`.
         let subset_r1p = iteration.variable_indistinct("subset_r1p");
@@ -66,6 +69,9 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
         let killed = all_facts.killed.into();
         let region_live_at = iteration.variable::<((Region, Point), ())>("region_live_at");
         let cfg_edge_p = iteration.variable::<(Point, Point)>("cfg_edge_p");
+
+        // output
+        let errors = iteration.variable("errors");
 
         // load initial facts.
         subset.insert(all_facts.outlives.into());
@@ -134,7 +140,10 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
             requires.from_join(&requires_2, &region_live_at, |&(r, q), &b, &()| (r, b, q));
 
             // borrow_live_at(B, P) :- requires(R, B, P), region_live_at(R, P)
-            borrow_live_at.from_join(&requires_rp, &region_live_at, |&(_r, p), &b, &()| (b, p));
+            borrow_live_at.from_join(&requires_rp, &region_live_at, |&(_r, p), &b, &()| ((b, p), ()));
+
+            // .decl errors(B, P) :- invalidates(B, P), borrow_live_at(B, P).
+            errors.from_join(&invalidates, &borrow_live_at, |&(b, p), &(), &()| (b, p));
         }
 
         if dump_enabled {
@@ -174,20 +183,20 @@ pub(super) fn compute<Region: Atom, Loan: Atom, Point: Atom>(
             }
         }
 
-        borrow_live_at.complete()
+        errors.complete()
     };
 
     if dump_enabled {
         println!(
-            "borrow_live_at is complete: {} tuples, {:?}",
-            borrow_live_at.len(),
-            borrow_live_at_start.elapsed()
+            "errors is complete: {} tuples, {:?}",
+            errors.len(),
+            computation_start.elapsed()
         );
     }
 
-    for (borrow, location) in &borrow_live_at.elements {
+    for (borrow, location) in &errors.elements {
         result
-            .borrow_live_at
+            .errors
             .entry(*location)
             .or_insert(Vec::new())
             .push(*borrow);

--- a/polonius-parser/src/ir.rs
+++ b/polonius-parser/src/ir.rs
@@ -37,8 +37,19 @@ pub enum Fact {
 
 impl Statement {
     crate fn new(effects: Vec<Effect>) -> Self {
+        // Anything live on entry to the "mid point" is also live on
+        // entry to the start point.
+        let effects_start = effects
+            .iter()
+            .filter(|effect| match effect {
+                Effect::Fact(Fact::RegionLiveAt { .. }) => true,
+                _ => false,
+            })
+            .cloned()
+            .collect();
+
         Self {
-            effects_start: Vec::new(),
+            effects_start,
             effects,
         }
     }

--- a/polonius-parser/src/ir.rs
+++ b/polonius-parser/src/ir.rs
@@ -20,13 +20,13 @@ pub struct Statement {
     pub effects: Vec<Effect>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Effect {
     Use { regions: Vec<String> },
     Fact(Fact),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Fact {
     Outlives { a: String, b: String },
     BorrowRegionAt { region: String, loan: String },

--- a/polonius-parser/src/parser.lalrpop
+++ b/polonius-parser/src/parser.lalrpop
@@ -26,7 +26,7 @@ Statement : Statement = {
 };
 
 Effects = Comma<Effect>;
-Effect = { 
+Effect = {
     <Fact> => Effect::Fact(<>),
     Use
 };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ pub struct Opt {
     skip_timing: bool,
     #[structopt(short = "v", long = "verbose", help = "Show intermediate output tuples and not just errors")]
     verbose: bool,
-    #[structopt(long = "graphviz_file", help = "Generate a graphviz file to visualize the input")]
+    #[structopt(long = "graphviz_file", help = "Generate a graphviz file to visualize the computation")]
     graphviz_file: Option<String>,
     #[structopt(short = "o", long = "output", help = "Directory where to output resulting tuples")]
     output_directory: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,15 +18,15 @@ pub struct Opt {
         raw(possible_values = "&Algorithm::variants()", case_insensitive = "true")
     )]
     algorithm: Algorithm,
-    #[structopt(long = "show-tuples")]
+    #[structopt(long = "show-tuples", help = "Show output tuples on stdout")]
     show_tuples: bool,
-    #[structopt(long = "skip-timing")]
+    #[structopt(long = "skip-timing", help = "Do not display timing results")]
     skip_timing: bool,
-    #[structopt(short = "v")]
+    #[structopt(short = "v", long = "verbose", help = "Show intermediate output tuples and not just errors")]
     verbose: bool,
-    #[structopt(long = "graphviz_file")]
+    #[structopt(long = "graphviz_file", help = "Generate a graphviz file to visualize the input")]
     graphviz_file: Option<String>,
-    #[structopt(short = "o", long = "output")]
+    #[structopt(short = "o", long = "output", help = "Directory where to output resulting tuples")]
     output_directory: Option<String>,
     #[structopt(raw(required = "true"))]
     fact_dirs: Vec<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,8 +18,8 @@ pub struct Opt {
         raw(possible_values = "&Algorithm::variants()", case_insensitive = "true")
     )]
     algorithm: Algorithm,
-    #[structopt(long = "skip-tuples")]
-    skip_tuples: bool,
+    #[structopt(long = "show-tuples")]
+    show_tuples: bool,
     #[structopt(long = "skip-timing")]
     skip_timing: bool,
     #[structopt(short = "v")]
@@ -59,7 +59,7 @@ pub fn main(opt: Opt) -> Result<(), Error> {
                         let millis = f64::from(duration.subsec_nanos()) * 0.000_000_001_f64;
                         println!("Time: {:0.3}s", seconds + millis);
                     }
-                    if !opt.skip_tuples {
+                    if opt.show_tuples {
                         dump::dump_output(&output, &output_directory, tables)
                             .expect("Failed to write output");
                     }

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -16,9 +16,9 @@ crate fn dump_output(
     intern: &InternerTables,
 ) -> io::Result<()> {
     dump_rows(
-        &mut writer_for(output_dir, "borrow_live_at")?,
+        &mut writer_for(output_dir, "errors")?,
         intern,
-        &output.borrow_live_at,
+        &output.errors,
     )?;
 
     if output.dump_enabled {
@@ -43,14 +43,9 @@ crate fn dump_output(
             &output.invalidates,
         )?;
         dump_rows(
-            &mut writer_for(output_dir, "errors")?,
+            &mut writer_for(output_dir, "borrow_live_at")?,
             intern,
-            &output.errors,
-        )?;
-        dump_rows(
-            &mut writer_for(output_dir, "subset")?,
-            intern,
-            &output.subset,
+            &output.borrow_live_at,
         )?;
         dump_rows(
             &mut writer_for(output_dir, "subset_anywhere")?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,5 +18,6 @@ mod intern;
 mod program;
 mod tab_delim;
 mod test;
+mod test_util;
 
 pub mod cli;

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use std::path::Path;
 
 fn test_facts(all_facts: &AllFacts, algorithms: &[Algorithm]) {
-    let naive = Output::compute(all_facts, Algorithm::Naive, false);
+    let naive = Output::compute(all_facts, Algorithm::Naive, true);
     for &optimized_algorithm in algorithms {
         println!("Algorithm {:?}", optimized_algorithm);
         let opt = Output::compute(all_facts, optimized_algorithm, true);

--- a/src/test.rs
+++ b/src/test.rs
@@ -131,7 +131,6 @@ fn no_subset_symmetries_exist() -> Result<(), Error> {
 // the length of the `outlives` chain reaching a live region at a specific point.
 
 #[test]
-#[should_panic]
 fn send_is_not_static_std_sync() {
     // Reduced from rustc test: ui/span/send-is-not-static-std-sync.rs
     // (in the functions: `mutex` and `rwlock`)
@@ -148,7 +147,6 @@ fn send_is_not_static_std_sync() {
 }
 
 #[test]
-#[should_panic]
 fn escape_upvar_nested() {
     // Reduced from rustc test: ui/nll/closure-requirements/escape-upvar-nested.rs
     // (in the function: `test-\{\{closure\}\}-\{\{closure\}\}/`)
@@ -167,7 +165,6 @@ fn escape_upvar_nested() {
 }
 
 #[test]
-#[should_panic]
 fn issue_31567() {
     // Reduced from rustc test: ui/nll/issue-31567.rs
     // This is one of two tuples present in the Naive results and missing from the Opt results,
@@ -177,7 +174,11 @@ fn issue_31567() {
     let program = r"
         universal_regions { }
         block B0 {
-            borrow_region_at('a, L0), outlives('a: 'b), outlives('b: 'c), outlives('c: 'd), region_live_at('d);
+            borrow_region_at('a, L0),
+            outlives('a: 'b),
+            outlives('b: 'c),
+            outlives('c: 'd),
+            region_live_at('d);
         }
     ";
 
@@ -187,7 +188,6 @@ fn issue_31567() {
 }
 
 #[test]
-#[should_panic]
 fn borrowed_local_error() {
     // This test is related to the previous 3: there is still a borrow_region outliving a live region,
     // through a chain of `outlives` at a single point, but this time there are also 2 points

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,6 +4,7 @@ use crate::facts::{Loan, Point, Region};
 use crate::intern;
 use crate::program::parse_from_program;
 use crate::tab_delim;
+use crate::test_util::assert_equal;
 use failure::Error;
 use polonius_engine::{Algorithm, Output};
 use rustc_hash::FxHashMap;
@@ -21,7 +22,7 @@ fn test_fn(dir_name: &str, fn_name: &str) -> Result<(), Error> {
         let all_facts = tab_delim::load_tab_delimited_facts(tables, &facts_dir)?;
         let naive = Output::compute(&all_facts, Algorithm::Naive, false);
         let opt = Output::compute(&all_facts, Algorithm::DatafrogOpt, true);
-        assert_eq!(naive.borrow_live_at, opt.borrow_live_at);
+        assert_equal(&naive.borrow_live_at, &opt.borrow_live_at);
     }
 }
 
@@ -57,7 +58,7 @@ fn test_insensitive_errors() -> Result<(), Error> {
         expected.insert(Point::from(1), vec![Loan::from(1)]);
         expected.insert(Point::from(2), vec![Loan::from(2)]);
 
-        assert_eq!(insensitive.errors, expected);
+        assert_equal(&insensitive.errors, &expected);
     }
 }
 
@@ -135,7 +136,7 @@ fn send_is_not_static_std_sync() {
 
     let naive = Output::compute(&facts, Algorithm::Naive, true);
     let opt = Output::compute(&facts, Algorithm::DatafrogOpt, true);
-    assert_eq!(naive.borrow_live_at, opt.borrow_live_at);
+    assert_equal(&naive.borrow_live_at, &opt.borrow_live_at);
 }
 
 #[test]
@@ -157,7 +158,7 @@ fn escape_upvar_nested() {
 
     let naive = Output::compute(&facts, Algorithm::Naive, true);
     let opt = Output::compute(&facts, Algorithm::DatafrogOpt, true);
-    assert_eq!(naive.borrow_live_at, opt.borrow_live_at);
+    assert_equal(&naive.borrow_live_at, &opt.borrow_live_at);
 }
 
 #[test]
@@ -180,7 +181,7 @@ fn issue_31567() {
 
     let naive = Output::compute(&facts, Algorithm::Naive, true);
     let opt = Output::compute(&facts, Algorithm::DatafrogOpt, true);
-    assert_eq!(naive.borrow_live_at, opt.borrow_live_at);
+    assert_equal(&naive.borrow_live_at, &opt.borrow_live_at);
 }
 
 #[test]
@@ -210,5 +211,5 @@ fn borrowed_local_error() {
 
     let naive = Output::compute(&facts, Algorithm::Naive, true);
     let opt = Output::compute(&facts, Algorithm::DatafrogOpt, true);
-    assert_eq!(naive.borrow_live_at, opt.borrow_live_at);
+    assert_equal(&naive.borrow_live_at, &opt.borrow_live_at);
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,46 @@
+#![cfg(test)]
+
+use std::fmt::Debug;
+
+/// Test that two values are equal, with a better error than `assert_eq`
+pub fn assert_equal<A>(expected_value: &A, actual_value: &A)
+where
+    A: ?Sized + Debug + Eq,
+{
+    // First check that they have the same debug text. This produces a better error.
+    let expected_text = format!("{:#?}", expected_value);
+    assert_expected_debug(&expected_text, actual_value);
+
+    // Then check that they are `eq` too, for good measure.
+    assert_eq!(expected_value, actual_value);
+}
+
+/// Test that the debug output of `actual_value` is as expected. Gives
+/// a nice diff if things fail.
+pub fn assert_expected_debug<A>(expected_text: &str, actual_value: &A)
+where
+    A: ?Sized + Debug,
+{
+    let actual_text = format!("{:#?}", actual_value);
+
+    if expected_text == actual_text {
+        return;
+    }
+
+    println!("# expected_text");
+    println!("{}", expected_text);
+
+    println!("# actual_text");
+    println!("{}", actual_text);
+
+    println!("# diff");
+    for diff in diff::lines(&expected_text, &actual_text) {
+        match diff {
+            diff::Result::Left(l) => println!("-{}", l),
+            diff::Result::Both(l, _) => println!(" {}", l),
+            diff::Result::Right(r) => println!("+{}", r),
+        }
+    }
+
+    panic!("debug comparison failed");
+}


### PR DESCRIPTION
The `borrow_live_at` relation as defined today is correct so long as
the "requires" originates from some previous statement.  But it is
overlooking one case where a borrow can be live within a single point
`P`:

If you have a `borrow_live_at(R, P, B)` at some point P where:

- `R` is dead on entry to P
- but `R <=* R2`
- and `R2` is live

then we don't handle this at all. So add some logic to detect this
case. Also do a bunch of other random cleanup. 