### PR TITLE
Invert loan and point arguments in loc insensitive check

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -25,7 +25,7 @@ fn test_facts(all_facts: &AllFacts, algorithms: &[Algorithm]) {
                             "naive analysis had error for `{:?}` at `{:?}` \
                              but insensitive analysis did not \
                              (loans = {:#?})",
-                            naive_point, naive_loan, insensitive_loans,
+                            naive_loan, naive_point, insensitive_loans,
                         );
                     }
                 }


### PR DESCRIPTION
A trivial change but I did manually test the message by injecting fake errors.

r? @nikomatsakis 